### PR TITLE
Added test for engine, corrected several bugs. Dropped sqrt weights.

### DIFF
--- a/src/tadbit.h
+++ b/src/tadbit.h
@@ -1,11 +1,17 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <pthread.h>
+#include <ctype.h>
+#include <unistd.h>
+#include <float.h>
 #include <pthread.h>
 
-#ifndef TADBIT_LOADED
-#define TADBIT_LOADED
+#ifndef _TADBIT_LOADED
+#define _TADBIT_LOADED
 
 #define TOLERANCE 1e-6
 #define MAXITER 10000
-
 
 typedef struct {
    const int n;
@@ -33,6 +39,7 @@ typedef struct {
 
 // 'tadbit' output struct.
 typedef struct {
+   int m;
    int maxbreaks;
    int nbreaks_opt;
    int *passages;
@@ -41,6 +48,7 @@ typedef struct {
    int *bkpts;
    double **weights;
 } tadbit_output;
+
 
 
 void
@@ -56,5 +64,11 @@ tadbit(
   const int do_not_use_heuristic,
   /* output */
   tadbit_output *seg
+);
+
+
+void
+destroy_tadbit_output(
+   tadbit_output *seg
 );
 #endif

--- a/src/tadbit_R.c
+++ b/src/tadbit_R.c
@@ -1,0 +1,161 @@
+#include <R.h>
+#include <Rinternals.h>
+#include <R_ext/Rdynload.h>
+#include "tadbit.h"
+
+// Declare and register R/C interface.
+SEXP
+tadbit_R_call(
+  SEXP list,
+  SEXP n_threads,
+  SEXP verbose,
+  SEXP max_tad_size,
+  SEXP heuristic
+);
+
+R_CallMethodDef callMethods[] = {
+   {"tadbit_R_call", (DL_FUNC) &tadbit_R_call, 5},
+   {NULL, NULL, 0}
+};
+
+void R_init_tadbit(DllInfo *info) {
+   R_registerRoutines(info, NULL, callMethods, NULL, NULL);
+}
+
+
+SEXP
+tadbit_R_call(
+  SEXP list,
+  SEXP n_threads,
+  SEXP verbose,
+  SEXP max_tad_size,
+  SEXP do_not_use_heuristic
+){
+
+/*
+   * This is a tadbit wrapper for R. The matrices have to be passed
+   * in a list (in R). Checks that the input consists of numeric
+   * square matrices, with identical dimensions. The list is
+   * is converted to pointer of pointers to doubles and passed
+   * to 'tadbit'.
+   * Assume that NAs can be passed from R and are ignored in the
+   * computation.
+*/
+
+   R_len_t i, m = length(list);
+   int first = 1, N, *dim_int;
+
+   SEXP dim;
+   PROTECT(dim = allocVector(INTSXP, 2));
+
+   // Convert 'obs_list' to pointer of pointer to double.
+   int **obs = (int **) malloc(m * sizeof(int **));
+   for (i = 0 ; i < m ; i++) {
+      // This fails if list element is not numeric.
+      obs[i] = INTEGER(coerceVector(VECTOR_ELT(list, i), INTSXP));
+      // Check that input is a matrix.
+      if (!isMatrix(VECTOR_ELT(list, i))) {
+         error("input must be square matrix");
+      }
+      // Check the dimension.
+      dim = getAttrib(VECTOR_ELT(list, i), R_DimSymbol);
+      dim_int = INTEGER(dim);
+      if (dim_int[0] != dim_int[1]) {
+         error("input must be square matrix");
+      }
+      if (first) {
+         N = dim_int[0];
+         first = 0;
+      }
+      else {
+         if (N != dim_int[0]) {
+            error("all matrices must have same dimensions");
+         }
+      }
+   }
+
+   UNPROTECT(1);
+
+   tadbit_output *seg = (tadbit_output *) malloc(sizeof(tadbit_output));
+   
+   // Call 'tadbit'.
+   tadbit(obs, N, m, INTEGER(n_threads)[0], INTEGER(verbose)[0],
+         INTEGER(max_tad_size)[0], INTEGER(do_not_use_heuristic)[0], seg);
+
+   int maxbreaks = seg->maxbreaks;
+
+   // Check that tadbit exited successfully.
+   if (maxbreaks == -1) {
+      free(obs);
+      free(seg);
+      SEXP fail_SEXP;
+      PROTECT(fail_SEXP = allocVector(INTSXP, 1));
+      int *fail = INTEGER(fail_SEXP);
+      fail[0] = -1;
+      SEXP list_SEXP;
+      PROTECT(list_SEXP = allocVector(VECSXP, 1));
+      SET_VECTOR_ELT(list_SEXP, 0, fail_SEXP);
+      UNPROTECT(2);
+      return list_SEXP;
+   }
+
+   // Copy output to R-readable variables.
+   SEXP nbreaks_SEXP;
+   SEXP passages_SEXP;
+   SEXP llikmat_SEXP;
+   SEXP mllik_SEXP;
+   SEXP bkpts_SEXP;
+
+   PROTECT(nbreaks_SEXP = allocVector(INTSXP, 1));
+   PROTECT(passages_SEXP = allocVector(INTSXP, N));
+   PROTECT(llikmat_SEXP = allocVector(REALSXP, N*N));
+   PROTECT(mllik_SEXP = allocVector(REALSXP, maxbreaks));
+   PROTECT(bkpts_SEXP = allocVector(INTSXP, N*(maxbreaks-1)));
+
+   int *nbreaks_opt = INTEGER(nbreaks_SEXP); 
+   int *passages = INTEGER(passages_SEXP); 
+   double *llikmat = REAL(llikmat_SEXP);
+   double *mllik = REAL(mllik_SEXP);
+   int *bkpts = INTEGER(bkpts_SEXP);
+
+   nbreaks_opt[0] = seg->nbreaks_opt;
+   for (i = 0 ; i < N ; i++) passages[i] = seg->passages[i];
+   for (i = 0 ; i < N*N ; i++) llikmat[i] = seg->llikmat[i];
+   for (i = 0 ; i < maxbreaks ; i++) mllik[i] = seg->mllik[i];
+   // Remove first column associated with 0 breaks. Itcontains only
+   // 0s and shifts the index in R (vectors start at position 1).
+   for (i = N ; i < N*(maxbreaks-1) ; i++) bkpts[i-N] = seg->bkpts[i];
+
+
+   // Set 'dim' attributes.
+   SEXP dim_llikmat;
+   PROTECT(dim_llikmat = allocVector(INTSXP, 2));
+   INTEGER(dim_llikmat)[0] = N;
+   INTEGER(dim_llikmat)[1] = N;
+   setAttrib(llikmat_SEXP, R_DimSymbol, dim_llikmat);
+
+   SEXP dim_breaks;
+   PROTECT(dim_breaks = allocVector(INTSXP, 2));
+   INTEGER(dim_breaks)[0] = N;
+   INTEGER(dim_breaks)[1] = maxbreaks-1;
+   setAttrib(bkpts_SEXP, R_DimSymbol, dim_breaks);
+
+   free(obs);
+   free(seg->passages);
+   free(seg->llikmat);
+   free(seg->mllik);
+   free(seg->bkpts);
+   free(seg);
+
+   SEXP list_SEXP;
+   PROTECT(list_SEXP = allocVector(VECSXP, 5));
+   SET_VECTOR_ELT(list_SEXP, 0, nbreaks_SEXP);
+   SET_VECTOR_ELT(list_SEXP, 1, llikmat_SEXP);
+   SET_VECTOR_ELT(list_SEXP, 2, mllik_SEXP);
+   SET_VECTOR_ELT(list_SEXP, 3, bkpts_SEXP);
+   SET_VECTOR_ELT(list_SEXP, 4, passages_SEXP);
+   UNPROTECT(8);
+
+   return list_SEXP;
+
+}

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -1,0 +1,20 @@
+vpath %.c ..
+vpath %.h ..
+
+P= testset
+OBJECTS= tadbit.o
+CFLAGS= -I.. `pkg-config --cflags glib-2.0` -g -pg -Wall -std=gnu99 \
+	          -O0 -fstrict-aliasing -fprofile-arcs -ftest-coverage
+LDLIBS= `pkg-config --libs glib-2.0` -lpthread -lm
+CC= gcc
+$(P): $(OBJECTS)
+
+clean:
+	rm -f testset *.o *.gcda *.gcno *.gcov gmon.out analysis.txt \
+		callgrind.out.* cache.txt
+
+test:
+	gtester --verbose --keep-going testset
+
+debug:
+	gdb --command=debug.gdb --args testset

--- a/src/test/debug.gdb
+++ b/src/test/debug.gdb
@@ -1,0 +1,2 @@
+b tadbit
+r

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,0 +1,9 @@
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <time.h>
+#include <glib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include "tadbit.h"

--- a/src/test/testset.c
+++ b/src/test/testset.c
@@ -1,0 +1,92 @@
+#include "test.h"
+
+char error_buffer[1024];
+int backup;
+
+
+void
+redirect_stderr_to
+(char buffer[])
+{
+   // Flush stderr, redirect to /dev/null and set buffer.
+   fflush(stderr);
+   int temp = open("/dev/null", O_WRONLY);
+   dup2(temp, STDERR_FILENO);
+   memset(buffer, '\0', 1024 * sizeof(char));
+   setvbuf(stderr, buffer, _IOFBF, 1024);
+   close(temp);
+   // Fill the buffer (needed for reset).
+   fprintf(stderr, "fill the buffer");
+   fflush(stderr);
+}
+
+void
+unredirect_sderr
+(void)
+{ 
+   fflush(stderr);
+   dup2(backup, STDERR_FILENO);
+   setvbuf(stderr, NULL, _IONBF, 0);
+}
+
+
+void
+test_tadbit
+(void)
+{
+
+   // -- INPUT -- //
+   int obs1[36] = {
+      32, 16,  8,  4,  2,  1,
+      16, 32, 16,  8,  4,  2,
+       8, 16, 32, 16,  8,  4,
+       4,  8, 16, 32, 16,  8,
+       2,  4,  8, 16, 32, 16,
+       1,  2,  4,  8, 16, 32,
+   };
+
+   int obs2[36] = {
+      32, 16,  8,  4,  2,  1,
+      16, 32, 16,  8,  4,  2,
+       8, 16, 32, 16,  8,  4,
+       4,  8, 16, 32, 16,  8,
+       2,  4,  8, 16, 32, 16,
+       1,  2,  4,  8, 16, 32,
+   };
+
+
+   int **obs = malloc(2 * sizeof(int *));
+   obs[0] = obs1;
+   obs[1] = obs2;
+
+   // -- OUTPUT -- //
+   tadbit_output *seg = malloc(sizeof(tadbit_output));
+
+   tadbit(obs, 6, 2, 1, 0, 6, 0, seg);
+
+   g_assert_cmpint(seg->maxbreaks, ==, 1);
+
+   free(obs);
+   destroy_tadbit_output(seg);
+   
+}
+
+int
+main(
+   int argc,
+   char **argv
+)
+{
+
+   // Store 'stderr', file descriptor.
+   backup = dup(STDERR_FILENO);
+
+   g_test_init(&argc, &argv, NULL);
+   g_test_add_func("/tadbit", test_tadbit);
+
+   int g_test_result = g_test_run();
+   close(backup);
+
+   return g_test_result;
+
+}


### PR DESCRIPTION
I wrote minimal testing for the C engine of tadbit. In the process I found several bugs in the code in particular a segmentation fault when matrices are small or full of 0's, a tiny memory leak, and some uncontrolled threading that caused undefined behavior. Those bugs are fixed and valgrind reports no leak on the minimal test.

I also wrote a helper function `destroy_tadbit_output` to remove the complicated data structure of tadbit.

Running `make` in the src directory should run fine. Running `make` in the src/test directory should run fine if glib2 is available. In this case running `make test` should report OK.
