### PR TITLE
chrom_start should start at 0

### DIFF
--- a/_pytadbit/modelling/structuralmodels.py
+++ b/_pytadbit/modelling/structuralmodels.py
@@ -2404,7 +2404,7 @@ class StructuralModels(object):
                 warn("WARNING: chrom_start variable wasn't set, setting it to" +
                      " the position in the experiment matrix (%s)" % (
                          str(my_descr['start'])))
-                my_descr['chrom_start'] = my_descr['start'] + 1
+                my_descr['chrom_start'] = my_descr['start']
             if 'chrom_end' not in my_descr:
                 warn("WARNING: chrom_end variable wasn't set, setting it to" +
                      " the position in the experiment matrix (%s)" % (


### PR DESCRIPTION
There has been always confusion on whether the TADkit json chrom_start
For example, if we have 12 bins at 20k starting at 0, right now it looks like: chrom_start: 20000, chrom_end: 240000
I think it's confusing , let's stick to: chrom_start: 0, chrom_end: 240000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/3dgenomes/tadbit/202)
<!-- Reviewable:end -->
