### PR TITLE
Use project, chromosome and region in the title of json

### DIFF
--- a/_pytadbit/experiment.py
+++ b/_pytadbit/experiment.py
@@ -1547,7 +1547,7 @@ class Experiment(object):
         if self.hic_data and self.hic_data[0].chromosomes:
             tot = 0
             chrs = []
-            chrom_offset_start = 0
+            chrom_offset_start = start
             chrom_offset_end = 0
             for k, v in self.hic_data[0].chromosomes.iteritems():
                 tot += v

--- a/scripts/model_and_analyze.py
+++ b/scripts/model_and_analyze.py
@@ -562,7 +562,7 @@ def main():
         logging.info("\t\tWARNING: plot for clusters could not be made...")
 
     if not opts.not_write_json:
-        models.write_json(os.path.join(opts.outdir, name, name + '.json'))
+        models.write_json(os.path.join(opts.outdir, name, name + '.json'), title = opts.project+' '+name if opts.project else name)
 
     if not (opts.not_write_xyz and opts.not_write_cmm):
         # Save the clustered models into directories for easy visualization with


### PR DESCRIPTION
Use project, chromosome and region in the title of generated tadkit json, thus avoiding all the jsons being named Sample Tadbit data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/3dgenomes/tadbit/208)
<!-- Reviewable:end -->
