### PR TITLE
ListSingletonContainer deprecated in imp 2.9.0

### DIFF
--- a/_pytadbit/modelling/imp_modelling.py
+++ b/_pytadbit/modelling/imp_modelling.py
@@ -301,7 +301,7 @@ def generate_IMPmodel(rand_init, HiCRestraints,use_HiC=True, use_confining_envir
              'model'      : Model(),
              'particles'  : None,
              'restraints' : None} # 2.6.1 compat
-    model['particles'] = ListSingletonContainer(
+    model['particles'] = ListSingletonContainer(model['model'],
         IMP.core.create_xyzr_particles(model['model'], len(LOCI), RADIUS, 100000/SCALE))  # last number is box size
 
     try:


### PR DESCRIPTION
The particle-based ListSingletonContainer has
been deprecated for some time, and was removed
shortly after the IMP 2.8.0 release, so these
scripts no longer work. Update to use the
particle index-based constructor instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/3dgenomes/tadbit/235)
<!-- Reviewable:end -->
