### PR TITLE
Last changes to allow TADdyn run with bonds loaded directly, and avoiding use of colvars

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 +-----------------------+-+
 |                       | |
-| Current version: pipeline_v0.2.703  |
+| Current version: pipeline_v0.2.705  |
 |                       | |
 +-----------------------+-+
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 +-----------------------+-+
 |                       | |
-| Current version: pipeline_v0.2.709  |
+| Current version: pipeline_v0.2.710  |
 |                       | |
 +-----------------------+-+
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 +-----------------------+-+
 |                       | |
-| Current version: pipeline_v0.2.707  |
+| Current version: pipeline_v0.2.709  |
 |                       | |
 +-----------------------+-+
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 +-----------------------+-+
 |                       | |
-| Current version: pipeline_v0.2.710  |
+| Current version: pipeline_v0.2.711  |
 |                       | |
 +-----------------------+-+
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 
 +-----------------------+-+
 |                       | |
-| Current version: pipeline_v0.2.705  |
+| Current version: pipeline_v0.2.707  |
 |                       | |
 +-----------------------+-+
 

--- a/_pytadbit/_version.py
+++ b/_pytadbit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "pipeline_v0.2.705"
+__version__ = "pipeline_v0.2.707"

--- a/_pytadbit/_version.py
+++ b/_pytadbit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "pipeline_v0.2.703"
+__version__ = "pipeline_v0.2.705"

--- a/_pytadbit/_version.py
+++ b/_pytadbit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "pipeline_v0.2.710"
+__version__ = "pipeline_v0.2.711"

--- a/_pytadbit/_version.py
+++ b/_pytadbit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "pipeline_v0.2.707"
+__version__ = "pipeline_v0.2.709"

--- a/_pytadbit/_version.py
+++ b/_pytadbit/_version.py
@@ -1,1 +1,1 @@
-__version__ = "pipeline_v0.2.709"
+__version__ = "pipeline_v0.2.710"

--- a/_pytadbit/experiment.py
+++ b/_pytadbit/experiment.py
@@ -845,7 +845,8 @@ class Experiment(object):
                      cleanup=True, single_particle_restraints=None, use_HiC=True,
                      start_seed=1, hide_log=True, remove_rstrn=[],
                      keep_restart_out_dir=None,
-                     restart_path=False, store_n_steps=10):
+                     restart_path=False, store_n_steps=10,
+                     useColvars=False):
         """
         Generates of three-dimensional models using IMP, for a given segment of
         chromosome.
@@ -933,6 +934,7 @@ class Experiment(object):
         :param False restart_path: path to files to restore LAMMPs session (binary)
         :param 10 store_n_steps: Integer with number of steps to be saved if 
                 restart_file != False
+        :param False useColvars: True if you want the restrains to be loaded by colvars
 
         :returns: a :class:`pytadbit.imp.structuralmodels.StructuralModels` object.
 
@@ -1004,7 +1006,8 @@ class Experiment(object):
                                       hide_log=hide_log, initial_seed=start_seed,
                                       remove_rstrn=remove_rstrn, restart_path=restart_path,
                                       keep_restart_out_dir=keep_restart_out_dir,
-                                      store_n_steps=store_n_steps
+                                      store_n_steps=store_n_steps,
+                                      useColvars=useColvars
                                       )
 
 

--- a/_pytadbit/experiment.py
+++ b/_pytadbit/experiment.py
@@ -844,8 +844,8 @@ class Experiment(object):
                      timesteps_per_k=10000, kfactor=1, adaptation_step=False,
                      cleanup=True, single_particle_restraints=None, use_HiC=True,
                      start_seed=1, hide_log=True, remove_rstrn=[],
-                     keep_restart_step=1000000, keep_restart_out_dir=None,
-                     restart_path=False):
+                     keep_restart_out_dir=None,
+                     restart_path=False, store_n_steps=10):
         """
         Generates of three-dimensional models using IMP, for a given segment of
         chromosome.
@@ -928,9 +928,11 @@ class Experiment(object):
             potential for neighbours
         :param True cleanup: delete lammps folder after completion
         :param [] remove_rstrn: list of particles which must not have restrains
-        :param 1000000 keep_restart_step: step to recover stopped computation
-        :param None keep_restart_out_dir: recover stopped computation
+        :param None keep_restart_out_dir: path to write files to restore LAMMPs 
+            session (binary)
         :param False restart_path: path to files to restore LAMMPs session (binary)
+        :param 10 store_n_steps: Integer with number of steps to be saved if 
+                restart_file != False
 
         :returns: a :class:`pytadbit.imp.structuralmodels.StructuralModels` object.
 
@@ -1001,8 +1003,8 @@ class Experiment(object):
                                       adaptation_step=adaptation_step, cleanup=cleanup,
                                       hide_log=hide_log, initial_seed=start_seed,
                                       remove_rstrn=remove_rstrn, restart_path=restart_path,
-                                      keep_restart_step=keep_restart_step, 
                                       keep_restart_out_dir=keep_restart_out_dir,
+                                      store_n_steps=store_n_steps
                                       )
 
 

--- a/_pytadbit/modelling/impoptimizer.py
+++ b/_pytadbit/modelling/impoptimizer.py
@@ -167,7 +167,8 @@ class IMPoptimizer(object):
              {[x],[y],[z]} a dictionary containing lists with x,y,x positions,
              e.g an IMPModel or LAMMPSModel object
         :param [] remove_rstrn: list of particles which must not have restrains
-        :param None keep_restart_out_dir: recover stopped computation
+        :param None keep_restart_out_dir: path to write files to restore LAMMPs
+                    session (binary)
         :param False restart_path: path to files to restore LAMMPs session (binary)
         :param 10 store_n_steps: Integer with number of steps to be saved if 
             restart_file != False

--- a/_pytadbit/modelling/impoptimizer.py
+++ b/_pytadbit/modelling/impoptimizer.py
@@ -361,7 +361,8 @@ class IMPoptimizer(object):
                                           keep_restart_out_dir=keep_restart_out_dir, kfactor=kfactor, 
                                           cleanup=cleanup, initial_conformation='tadbit' if not initial_conformation \
                                             else initial_conformation,
-                                          restart_path=restart_path, remove_rstrn=remove_rstrn)
+                                          restart_path=restart_path, remove_rstrn=remove_rstrn,
+					  store_n_steps=store_n_steps)
                     result = 0
                     matrices = tdm.get_contact_matrix(
                         #cutoff=[int(i * self.resolution * float(scale)) for i in dcutoff_arange])

--- a/_pytadbit/modelling/impoptimizer.py
+++ b/_pytadbit/modelling/impoptimizer.py
@@ -123,8 +123,7 @@ class IMPoptimizer(object):
                         connectivity="FENE", hide_log=True,
                         kfactor=1, cleanup=False,
                         initial_conformation=None,
-                        remove_rstrn=[],
-                        keep_restart_step=1000000, keep_restart_out_dir=None,
+                        remove_rstrn=[],keep_restart_out_dir=None,
                         restart_path=False):
         """
         This function calculates the correlation between the models generated
@@ -168,7 +167,6 @@ class IMPoptimizer(object):
              {[x],[y],[z]} a dictionary containing lists with x,y,x positions,
              e.g an IMPModel or LAMMPSModel object
         :param [] remove_rstrn: list of particles which must not have restrains
-        :param 1000000 keep_restart_step: step to recover stopped computation
         :param None keep_restart_out_dir: recover stopped computation
         :param False restart_path: path to files to restore LAMMPs session (binary)
 
@@ -356,7 +354,7 @@ class IMPoptimizer(object):
                                           close_bins=self.close_bins, config=config_tmp,
                                           container=self.container, zeros=self.zeros,
                                           tmp_folder=self.tmp_folder,timeout_job=timeout_job,
-					                      hide_log=hide_log, keep_restart_step=keep_restart_step, 
+					                      hide_log=hide_log, 
                                           keep_restart_out_dir=keep_restart_out_dir, kfactor=kfactor, 
                                           cleanup=cleanup, initial_conformation='tadbit' if not initial_conformation \
                                             else initial_conformation,

--- a/_pytadbit/modelling/impoptimizer.py
+++ b/_pytadbit/modelling/impoptimizer.py
@@ -125,7 +125,8 @@ class IMPoptimizer(object):
                         initial_conformation=None,
                         remove_rstrn=[], initial_seed=0,
                         keep_restart_out_dir=None,
-                        restart_path=False, store_n_steps=10):
+                        restart_path=False, store_n_steps=10,
+                        useColvars=False):
         """
         This function calculates the correlation between the models generated
         by IMP and the input data for the four main IMP parameters (scale,
@@ -173,6 +174,7 @@ class IMPoptimizer(object):
         :param False restart_path: path to files to restore LAMMPs session (binary)
         :param 10 store_n_steps: Integer with number of steps to be saved if 
             restart_file != False
+        :param False useColvars: True if you want the restrains to be loaded by colvars
 
         """
         if verbose:
@@ -363,7 +365,8 @@ class IMPoptimizer(object):
                                           cleanup=cleanup, initial_conformation='tadbit' if not initial_conformation \
                                             else initial_conformation,
                                           restart_path=restart_path, remove_rstrn=remove_rstrn,
-                                          initial_seed=initial_seed, store_n_steps=store_n_steps)
+                                          initial_seed=initial_seed, store_n_steps=store_n_steps,
+                                          useColvars=useColvars)
                     result = 0
                     matrices = tdm.get_contact_matrix(
                         #cutoff=[int(dc * self.resolution * float(scale)) for dc in dcutoff_arange])

--- a/_pytadbit/modelling/impoptimizer.py
+++ b/_pytadbit/modelling/impoptimizer.py
@@ -124,7 +124,7 @@ class IMPoptimizer(object):
                         kfactor=1, cleanup=False,
                         initial_conformation=None,
                         remove_rstrn=[],keep_restart_out_dir=None,
-                        restart_path=False):
+                        restart_path=False, store_n_steps=10):
         """
         This function calculates the correlation between the models generated
         by IMP and the input data for the four main IMP parameters (scale,
@@ -169,6 +169,8 @@ class IMPoptimizer(object):
         :param [] remove_rstrn: list of particles which must not have restrains
         :param None keep_restart_out_dir: recover stopped computation
         :param False restart_path: path to files to restore LAMMPs session (binary)
+        :param 10 store_n_steps: Integer with number of steps to be saved if 
+            restart_file != False
 
         """
         if verbose:

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -1403,9 +1403,21 @@ def run_lammps(kseed, lammps_folder, run_time,
             result.append(lammps_model)
 
     #os.remove("%slog.cite" % lammps_folder)
+    # safe finished model
     if model_path != False:
         with open(model_path, "wb") as output_file:
             dump((kseed,result), output_file)
+    ################### Special case for clusters with disk quota
+    # Remove the saved steps
+    if saveRestart == True:
+        if os.path.isdir(restart_file):
+            restart_path = restart_file
+        else:
+            restart_path = '/'.join(restart_file.split('/')[:-1]) + '/'
+        for pathfile in os.listdir(restart_path):
+	    if pathfile.startswith('restart'):
+                os.remove(restart_path + pathfile)    
+    ##################################################################
 
     return (kseed,result)
 

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -70,7 +70,8 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
                        timesteps_per_k=10000,keep_restart_out_dir=None,
                        kfactor=1, adaptation_step=False, cleanup=False,
                        hide_log=True, remove_rstrn=[], initial_seed=0,
-                       restart_path=False, store_n_steps=10):
+                       restart_path=False, store_n_steps=10,
+                       useColvars=False):
     """
     This function generates three-dimensional models starting from Hi-C data.
     The final analysis will be performed on the n_keep top models.
@@ -171,6 +172,7 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
     :param False restart_path: path to files to restore LAMMPs session (binary)
     :param 10 store_n_steps: Integer with number of steps to be saved if 
         restart_file != False
+    :param False useColvars: True if you want the restrains to be loaded by colvars
 
     :returns: a StructuralModels object
     """
@@ -296,7 +298,8 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
                              confining_environment=container, timeout_job=timeout_job,
                              cleanup=cleanup, to_dump=int(timesteps_per_k/100.),
                              hide_log=hide_log, restart_path=restart_path,
-                             store_n_steps=store_n_steps)
+                             store_n_steps=store_n_steps,
+                             useColvars=useColvars)
 
     try:
         xpr = experiment
@@ -519,7 +522,8 @@ def lammps_simulate(lammps_folder, run_time,
                     to_dump=100000, pbc=False, timeout_job=3600,
                     hide_log=True,
                     restart_path=False,
-                    store_n_steps=10):
+                    store_n_steps=10,
+                    useColvars=False):
 
     """
     This function launches jobs to generate three-dimensional models in lammps
@@ -570,6 +574,7 @@ def lammps_simulate(lammps_folder, run_time,
     :param False restart_path: path to files to restore LAMMPs session (binary)
     :param 10 store_n_steps: Integer with number of steps to be saved if 
         restart_file != False
+    :param False useColvars: True if you want the restrains to be loaded by colvars
 
     :returns: a StructuralModels object
 
@@ -701,7 +706,8 @@ def lammps_simulate(lammps_folder, run_time,
                                 keep_restart_out_dir2,
                                 restart_file,
                                 model_path,
-                                store_n_steps,), callback=collect_result)
+                                store_n_steps,
+                                useColvars,), callback=collect_result)
     #                         , timeout=timeout_job)
 
     pool.close()
@@ -830,7 +836,7 @@ def run_lammps(kseed, lammps_folder, run_time,
     :param False model_path: path to/for pickle with finished model (name included)
     :param 10 store_n_steps: Integer with number of steps to be saved if 
         restart_file != False
-    :param False useColvars: True if you want the restrains to be loaded from by colvars
+    :param False useColvars: True if you want the restrains to be loaded by colvars
     :returns: a LAMMPSModel object
 
     """

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -414,8 +414,10 @@ def init_lammps_run(lmp, initial_conformation,
     ##########################
     if restart_file == False :
         lmp.command("read_data %s" % initial_conformation)
-    else restart_file:
+    else:
         lmp.command("read_restart %s" % restart_file)
+        print 'Previous unfinished LAMMPS steps found'
+        print 'Loaded %s file' %restart_file
     lmp.command("mass %s" % CONFIG.mass)
 
     ##################################################################
@@ -601,6 +603,8 @@ def lammps_simulate(lammps_folder, run_time,
         #print "#RandomSeed: %s" % k
         k_folder = lammps_folder + 'lammps_' + str(k) + '/'
         keep_restart_out_dir2 = keep_restart_out_dir + 'lammps_' + str(k) + '/'
+        if not os.path.exists(keep_restart_out_dir2):
+            os.makedirs(keep_restart_out_dir2)
         if restart_path != False:
             # check presence of previously finished jobs
             model_path = restart_path + 'lammps_' + str(k) + '/finishedModel_%s.pickle' %k
@@ -621,7 +625,7 @@ def lammps_simulate(lammps_folder, run_time,
                             if step > maxi[0]:
                                 maxi = (step, f)
                     # In case there is no restart file at all
-                    if maxi[1] = '':
+                    if maxi[1] == '':
                         print 'Could not find a LAMMPS restart file'
                         restart_file = False
                     else:
@@ -823,9 +827,7 @@ def run_lammps(kseed, lammps_folder, run_time,
     # was written) which was represented internally by LAMMPS in binary format. A new simulation 
     # which reads the data file will thus typically diverge from a simulation that continued 
     # in the original input script." will continue with binary. To convert use restart2data
-    if keep_restart_out_dir:
-        if not os.path.exists(keep_restart_out_dir):
-            os.makedirs(keep_restart_out_dir)
+    if keep_restart_out_dir2:
         lmp.command("restart %i %s/relaxation_%i_*.restart" % (keep_restart_step, keep_restart_out_dir2, kseed))
 
 

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -158,7 +158,8 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
     :param True hide_log: do not generate lammps log information
     :param FENE connectivity: use FENE for a fene bond or harmonic for harmonic
         potential for neighbours
-    :param None keep_restart_out_dir: recover stopped computation
+    :param None keep_restart_out_dir: path to write files to restore LAMMPs
+                session (binary)
     :param True cleanup: delete lammps folder after completion
     :param [] remove_rstrn: list of particles which must not have restrains
     :param 0 initial_seed: Initial random seed for modelling.
@@ -560,7 +561,8 @@ def lammps_simulate(lammps_folder, run_time,
     :param 500 n_models: number of models to generate.
     :param CONFIG.neighbor neighbor: see LAMMPS_CONFIG.py.
     :param True minimize: whether to apply minimize command or not. 
-    :param None keep_restart_out_dir: recover stopped computation
+    :param None keep_restart_out_dir: path to write files to restore LAMMPs
+                session (binary)
     :param None outfile: store result in outfile
     :param 1 n_cpus: number of CPUs to use.
     :param False restart_path: path to files to restore LAMMPs session (binary)
@@ -795,7 +797,8 @@ def run_lammps(kseed, lammps_folder, run_time,
                              }
 
             Should at least contain Chromosome, loci1, loci2 as 1st, 2nd and 3rd column 
-    :param None keep_restart_out_dir2: recover stopped computation
+    :param None keep_restart_out_dir2: path to write files to restore LAMMPs
+                session (binary)
     :param False restart_file: path to file to restore LAMMPs session (binary)
     :param False model_path: path to/for pickle with finished model (name included)
     :param 10 store_n_steps: Integer with number of steps to be saved if 

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -65,7 +65,7 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
                        timesteps_per_k=10000,keep_restart_out_dir=None,
                        kfactor=1, adaptation_step=False, cleanup=False,
                        hide_log=True, remove_rstrn=[], initial_seed=0,
-                       restart_path=False):
+                       restart_path=False, store_n_steps=10):
     """
     This function generates three-dimensional models starting from Hi-C data.
     The final analysis will be performed on the n_keep top models.
@@ -163,6 +163,8 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
     :param [] remove_rstrn: list of particles which must not have restrains
     :param 0 initial_seed: Initial random seed for modelling.
     :param False restart_path: path to files to restore LAMMPs session (binary)
+    :param 10 store_n_steps: Integer with number of steps to be saved if 
+        restart_file != False
 
     :returns: a StructuralModels object
     """
@@ -288,7 +290,8 @@ def generate_lammps_models(zscores, resolution, nloci, start=1, n_models=5000,
                              keep_restart_out_dir=keep_restart_out_dir,
                              confining_environment=container, timeout_job=timeout_job,
                              cleanup=cleanup, to_dump=int(timesteps_per_k/100.),
-                             hide_log=hide_log, restart_path=restart_path)
+                             hide_log=hide_log, restart_path=restart_path,
+                             store_n_steps=store_n_steps)
 
     try:
         xpr = experiment
@@ -512,7 +515,8 @@ def lammps_simulate(lammps_folder, run_time,
                     loop_extrusion_dynamics=None, cleanup = True,
                     to_dump=100000, pbc=False, timeout_job=3600,
                     hide_log=True,
-                    restart_path=False):
+                    restart_path=False,
+                    store_n_steps=10):
 
     """
     This function launches jobs to generate three-dimensional models in lammps
@@ -560,7 +564,9 @@ def lammps_simulate(lammps_folder, run_time,
     :param None outfile: store result in outfile
     :param 1 n_cpus: number of CPUs to use.
     :param False restart_path: path to files to restore LAMMPs session (binary)
-    
+    :param 10 store_n_steps: Integer with number of steps to be saved if 
+        restart_file != False
+
     :returns: a StructuralModels object
 
     """
@@ -666,7 +672,8 @@ def lammps_simulate(lammps_folder, run_time,
                                     to_dump, pbc, hide_log,
                                     keep_restart_out_dir2,
                                     restart_file,
-                                    model_path,), callback=collect_result)
+                                    model_path,
+                                    store_n_steps,), callback=collect_result)
         #                         , timeout=timeout_job)
 
     pool.close()
@@ -726,7 +733,8 @@ def run_lammps(kseed, lammps_folder, run_time,
                hide_log=True,
                keep_restart_out_dir2=None,
                restart_file=False,
-               model_path=False):
+               model_path=False, 
+               store_n_steps=10):
     """
     Generates one lammps model
     
@@ -790,7 +798,8 @@ def run_lammps(kseed, lammps_folder, run_time,
     :param None keep_restart_out_dir2: recover stopped computation
     :param False restart_file: path to file to restore LAMMPs session (binary)
     :param False model_path: path to/for pickle with finished model (name included)
-
+    :param 10 store_n_steps: Integer with number of steps to be saved if 
+        restart_file != False
     :returns: a LAMMPSModel object
 
     """
@@ -1016,7 +1025,7 @@ def run_lammps(kseed, lammps_folder, run_time,
                 else:
                     restart_file_new = '/'.join(restart_file.split('/')[:-1]) + '/restart_kincrease_%s_time_*.restart' %(kincrease)
                 print restart_file_new
-                lmp.command("restart %i %s" %(int(steering_pairs['timesteps_per_k']/10), restart_file_new))
+                lmp.command("restart %i %s" %(int(steering_pairs['timesteps_per_k']/store_n_steps), restart_file_new))
 
             #lmp.command("reset_timestep %i" % resettime)
             lmp.command("run %i" % runtime)

--- a/_pytadbit/modelling/lammps_modelling.py
+++ b/_pytadbit/modelling/lammps_modelling.py
@@ -1415,7 +1415,7 @@ def run_lammps(kseed, lammps_folder, run_time,
         else:
             restart_path = '/'.join(restart_file.split('/')[:-1]) + '/'
         for pathfile in os.listdir(restart_path):
-	    if pathfile.startswith('restart'):
+	        if pathfile.startswith('restart'):
                 os.remove(restart_path + pathfile)    
     ##################################################################
 


### PR DESCRIPTION
In this change will set the restrains to start at zero and increase to their real value in each step, line 1894 of _pytadbit/modelling/lammps_modelling.py --> initial kappa = 0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/3dgenomes/tadbit/304)
<!-- Reviewable:end -->
