### PR TITLE
Update Singularity file defintion to avoid keyserver errors

### DIFF
--- a/containers/TADbit_singularity.def
+++ b/containers/TADbit_singularity.def
@@ -18,7 +18,8 @@ From:neurodebian:buster
   apt-get update --fix-missing
 
   apt install -y dirmngr apt-transport-https ca-certificates software-properties-common gnupg2 wget
-  apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key 'B8F25A8A73EACF41'	
   add-apt-repository 'deb https://cloud.r-project.org/bin/linux/debian buster-cran35/'
 
   apt-get update --fix-missing


### PR DESCRIPTION
keys.gnupg.net has been deprecated now, so I changed it to the ubuntu keyserver keyserver.ubuntu.com.

Also since I was having problems with eduroam, since it blocks most ports (gpg uses 11371 by default), I added explicity the protocol and port number 80. This still works for other networks too.